### PR TITLE
update lock file to bring in 0.3.3 bigcommerce/grphp

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "09abe31eae748e75ddc6b9b588c4f651",
+    "content-hash": "e3d91e18b2237ff3a87e651f06b9530b",
     "packages": [
         {
             "name": "domnikl/statsd",
@@ -106,23 +106,23 @@
     "packages-dev": [
         {
             "name": "bigcommerce/grphp",
-            "version": "v0.3.1",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "git@github.com:bigcommerce/grphp.git",
-                "reference": "2ce9eee053597b5422b7ce5e70e55d31018de3e4"
+                "reference": "e3e26d6d7035c0b2836a11d25f0b5df1bb1cf16b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigcommerce/grphp/zipball/2ce9eee053597b5422b7ce5e70e55d31018de3e4",
-                "reference": "2ce9eee053597b5422b7ce5e70e55d31018de3e4",
+                "url": "https://api.github.com/repos/bigcommerce/grphp/zipball/e3e26d6d7035c0b2836a11d25f0b5df1bb1cf16b",
+                "reference": "e3e26d6d7035c0b2836a11d25f0b5df1bb1cf16b",
                 "shasum": ""
             },
             "require": {
                 "phpunit/php-timer": "1.0.*"
             },
             "require-dev": {
-                "grpc/grpc": "1.3.2.*",
+                "bigcommerce/grpc-php": "dev-bc-1.3.2",
                 "phpunit/php-code-coverage": "^5.2@dev",
                 "phpunit/phpunit": "6.1.*"
             },
@@ -137,10 +137,10 @@
             ],
             "description": "gRPC PHP Framework",
             "support": {
-                "source": "https://github.com/bigcommerce/grphp/tree/v0.3.1",
+                "source": "https://github.com/bigcommerce/grphp/tree/0.3.3",
                 "issues": "https://github.com/bigcommerce/grphp/issues"
             },
-            "time": "2017-07-21T20:22:52+00:00"
+            "time": "2017-09-14T18:35:18+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -195,47 +195,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "grpc/grpc",
-            "version": "v1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/grpc/grpc.git",
-                "reference": "5cb6a1f86129fc2833de9a27cfe174260934342b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc/zipball/5cb6a1f86129fc2833de9a27cfe174260934342b",
-                "reference": "5cb6a1f86129fc2833de9a27cfe174260934342b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "google/auth": "v0.9"
-            },
-            "suggest": {
-                "ext-protobuf": "For better performance, install the protobuf C extension.",
-                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\": "src/php/lib/Grpc/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "gRPC library for PHP",
-            "homepage": "http://grpc.io",
-            "keywords": [
-                "rpc"
-            ],
-            "time": "2017-07-11T21:11:30+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1049,12 +1008,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ed724f5d860f9a4cf8eb8ba27ea45cac9541bb5b"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ed724f5d860f9a4cf8eb8ba27ea45cac9541bb5b",
-                "reference": "ed724f5d860f9a4cf8eb8ba27ea45cac9541bb5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
@@ -1093,7 +1052,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-07-13 02:44:20"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1586,7 +1545,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "phpunit/php-code-coverage": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
Also remove `grpc/grpc` from the lockfile as this has been replaced with `bigcommerce/grpc-php` but is not explicitly removed without running update on the package.

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 0 updates, 1 removal
  - Removing grpc/grpc (v1.4.2)
Writing lock file
Generating autoload files
```

ping @bc-services @precariouspanther @PascalZajac @chrisboulton 