### PR TITLE
Improvements: .gitattributes, Travis CI, composer.json and coding style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ tmp
 test.php
 coverage/
 /composer.lock
+/.php_cs
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,4 +8,10 @@
     )
     ->setRules([
         '@PSR2' => true,
+        'header_comment' => [
+            'comment_type' => 'PHPDoc',
+            'header' => trim(file_get_contents(__DIR__ . '/LICENSE.md')),
+            'location' => 'after_open',
+            'separate' => 'none',
+        ],
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,11 @@
+<?php
+ return PhpCsFixer\Config::create()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->files()
+            ->in(__DIR__ . '/src')
+            ->in(__DIR__ . '/tests')
+    )
+    ->setRules([
+        '@PSR2' => true,
+    ]);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,34 @@
-language: php
-php:
-  - 7.0
-  - 7.1
 sudo: false
-dist: trusty
-before_script:
-  - composer install
-script:
-  - vendor/bin/phpunit --configuration phpunit.xml.dist
+
+cache:
+    directories:
+        - $HOME/.composer
+
+git:
+    depth: 1
+
+language: php
+
+before_install:
+    - composer self-update
+    - phpenv config-rm xdebug.ini || return 0
+    - composer global show hirak/prestissimo -q || composer global require hirak/prestissimo
+
 matrix:
-  fast_finish: true
+    include:
+        - name: PHP 7.0 with lowest versions of dependencies
+          php: '7.0'
+          install: composer update --prefer-lowest
+        - name: PHP 7.0
+          php: '7.0'
+          install: composer update
+        - name: PHP 7.1
+          php: '7.1'
+          install: composer update
+        - name: PHP 7.2
+          php: '7.2'
+          install: composer update
+
+script:
+    - vendor/bin/phpcs --standard=PSR2 --ignore=src/Grphp/grpc.stubs.php src
+    - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ matrix:
           install: composer update
 
 script:
-    - vendor/bin/phpcs --standard=PSR2 --ignore=src/Grphp/grpc.stubs.php src
+    - vendor/bin/php-cs-fixer fix --diff --dry-run -v
     - vendor/bin/phpunit

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,8 @@ Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the 
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
-persons to whom the Software is furnished to do so, subject to the following conditions:
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
 Software.

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,33 @@
 {
   "name": "bigcommerce/grphp-statsd",
-  "description": "grphp statsd interceptor",
   "type": "library",
-  "minimum-stability": "dev",
-  "prefer-stable": true,
+  "description": "grphp statsd interceptor",
   "license": "MIT",
-  "repositories": [
-    { "type": "vcs", "url": "git@github.com:bigcommerce/grphp.git" }
-  ],
   "require": {
     "php": "^7.0",
     "domnikl/statsd": "~2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "6.1.*",
+    "bigcommerce/grphp": "0.3.8",
     "phpunit/php-code-coverage": "^5.2@dev",
-    "bigcommerce/grphp": "0.3.8"
-  },
-  "autoload": {
-    "psr-4": { "": "src/"}
+    "phpunit/phpunit": "6.1.*"
   },
   "config": {
     "platform": {
       "php": "7.0.30"
     }
-  }
+  },
+  "autoload": {
+    "psr-4": {
+      "": "src/"
+    }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:bigcommerce/grphp.git"
+    }
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -12,22 +12,9 @@
     "phpunit/php-code-coverage": "^5.2@dev",
     "phpunit/phpunit": "6.1.*"
   },
-  "config": {
-    "platform": {
-      "php": "7.0.30"
-    }
-  },
   "autoload": {
     "psr-4": {
       "Grphp\\StatsD\\": "src/Grphp/StatsD"
     }
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "git@github.com:bigcommerce/grphp.git"
-    }
-  ],
-  "minimum-stability": "dev",
-  "prefer-stable": true
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
   },
   "require-dev": {
     "bigcommerce/grphp": "0.3.8",
+    "friendsofphp/php-cs-fixer": "^2.13",
     "phpunit/phpunit": "^6.4 || ^7.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     { "type": "vcs", "url": "git@github.com:bigcommerce/grphp.git" }
   ],
   "require": {
+    "php": "^7.0",
     "domnikl/statsd": "~2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "autoload": {
     "psr-4": {
-      "": "src/"
+      "Grphp\\StatsD\\": "src/Grphp/StatsD"
     }
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
   },
   "require-dev": {
     "bigcommerce/grphp": "0.3.8",
-    "phpunit/php-code-coverage": "^5.2@dev",
-    "phpunit/phpunit": "6.1.*"
+    "phpunit/phpunit": "^6.4 || ^7.4"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Support/BaseTest.php
+++ b/tests/Support/BaseTest.php
@@ -21,5 +21,4 @@ use PHPUnit\Framework\TestCase;
 
 class BaseTest extends TestCase
 {
-
 }

--- a/tests/Support/TestStub.php
+++ b/tests/Support/TestStub.php
@@ -19,12 +19,10 @@ namespace Grphp\Statsd\Test;
 
 class BaseStub
 {
-
 }
 
 class TestClient extends BaseStub
 {
-
 }
 
 class CallStatus

--- a/tests/Unit/Grphp/StatsD/InterceptorTest.php
+++ b/tests/Unit/Grphp/StatsD/InterceptorTest.php
@@ -44,8 +44,7 @@ class InterceptorTest extends BaseTest
         $s = new TestClient();
         $i->setStub($s);
         $i->setMethod($method);
-        $i->call(function()
-        {
+        $i->call(function () {
             $message = new \stdClass();
             $status = new CallStatus();
             $resp = new Response($message, $status);
@@ -59,5 +58,4 @@ class InterceptorTest extends BaseTest
             ['get_thing', 'grphp.statsd.test.test_client.get_thing'],
         ];
     }
-
 }


### PR DESCRIPTION
This PR:
- adds .gitattributes ([reasoning](https://github.com/bigcommerce/bigcommerce-api-php/pull/238))
- updates Travis CI configuration (similar as [here](https://github.com/bigcommerce/grphp/pull/21))
- [normalizes](https://github.com/localheinz/composer-normalize) `composer.json`
- fixes autoload configuration
- removes unnecessary options from `composer.json`
- upgrades PHPUnit to use v7 in PHP 7.1+
- adds [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and fixes code with it to follow PSR2
- unifies header comments