### PR TITLE
move from domnikl/statsd to slickdeals/statsd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "require": {
     "php": "^7.0 || ^8.0",
-    "domnikl/statsd": "^3.0"
+    "slickdeals/statsd": "^3.1"
   },
   "require-dev": {
     "bigcommerce/grphp": "^3.0",


### PR DESCRIPTION
`domnikl/statsd` package was abandoned and not maintained anymore. But there is a fork of this package that continue support. This PR replacing `domnikl/statsd` to `slickdeals/statsd`.