### PR TITLE
FE-190 Use SATIS to publish a composer branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       - ci/pre-setup
       - php/install-extensions:
-          composer_version: ''
-          additional_apt_packages: ''
-          additional_php_extensions: ''
-          additional_pecl_extensions: ''
+          composer_version: ""
+          additional_apt_packages: ""
+          additional_php_extensions: ""
+          additional_pecl_extensions: ""
       - php/composer-install
       - php/unit-phpunit:
-          configuration: 'phpunit.xml.dist'
+          configuration: "phpunit.xml.dist"
   cs-fixer:
     parameters:
       php-version:
@@ -34,10 +34,10 @@ jobs:
     steps:
       - ci/pre-setup
       - php/install-extensions:
-          composer_version: ''
-          additional_apt_packages: ''
-          additional_php_extensions: ''
-          additional_pecl_extensions: ''
+          composer_version: ""
+          additional_apt_packages: ""
+          additional_php_extensions: ""
+          additional_pecl_extensions: ""
       - php/composer-install
       - run: ./vendor/bin/php-cs-fixer fix --diff --dry-run -v
 
@@ -48,8 +48,13 @@ workflows:
       - tests-unit:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: ["7.3-fpm", "7.4-fpm", "8.0-fpm"]
       - cs-fixer:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: ["7.3-fpm", "7.4-fpm", "8.0-fpm"]
+      - php/composer-github:
+          filters:
+            tags:
+              only:
+                - /.*/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "bigcommerce/grphp-statsd",
+  "homepage": "https://github.com/bigcommerce/grphp-statsd",
   "type": "library",
   "description": "grphp statsd interceptor",
   "license": "MIT",


### PR DESCRIPTION
# What / Why?

Use [SATIS](https://github.com/composer/satis) to create a composer branch so it can be used to install dependencies without cloning each branch.

This step will run upon merging in master and create a `composer` branch containing a static version of a composer registry that can be used in `composer.json` to retrieve the available tags/branches.

@bigcommerce/husky @joec4i @TomA-R @cwalsh @PascalZajac @bigcommerce/data-engineers