### PR TITLE
Remove unused composer_version parameter from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - ci/pre-setup
       - php/install-extensions:
-          composer_version: ''
           additional_apt_packages: ''
           additional_php_extensions: ''
           additional_pecl_extensions: ''
@@ -34,7 +33,6 @@ jobs:
     steps:
       - ci/pre-setup
       - php/install-extensions:
-          composer_version: ''
           additional_apt_packages: ''
           additional_php_extensions: ''
           additional_pecl_extensions: ''


### PR DESCRIPTION
## What & Why
The `composer_version` parameter of the `install-extensions` command will be removed from the orb soon and in order to prevent breaking builds we are removing it ahead of time.

@bigcommerce/php