### PR TITLE
correct version for php image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: 7.3-fpm
+        default: "7.3"
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -26,7 +26,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: 7.3-fpm
+        default: "7.3"
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -46,8 +46,8 @@ workflows:
       - tests-unit:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: [ "7.3", "7.4", "8.0" ]
       - cs-fixer:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: [ "7.3", "7.4", "8.0" ]


### PR DESCRIPTION
## What?
Change `php-version` parameter from `8.0-fpm` to `8.0`.

## Why?
Currently `php/php` executor is based on deprecated `circleci/php` image. This image has a lot of variants, starting from `php:8.0` and ending with `php:8.0-fpm-apache-buster`.
In order to support newer versions of php we need to migrate to `cimg/php`. This image has only there variants `php:8.0`, `php:8.0-node` and `php:8.0-browsers`.
Changing `php-version` parameter will unblock migration to `cimg/php`.

## Testing / Proof
If CircleCi checks are green - we good.