### PR TITLE
Stop building against PHP 7.3 and 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: "7.3"
+        default: "8.0"
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -46,8 +46,8 @@ workflows:
       - tests-unit:
           matrix:
             parameters:
-              php-version: [ "7.3", "7.4", "8.0" ]
+              php-version: [ "8.0" ]
       - cs-fixer:
           matrix:
             parameters:
-              php-version: [ "7.3", "7.4", "8.0" ]
+              php-version: [ "8.0" ]

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "grphp statsd interceptor",
   "license": "MIT",
   "require": {
-    "php": "^7.0 || ^8.0",
+    "php": "^8.0",
     "slickdeals/statsd": "^3.1"
   },
   "require-dev": {


### PR DESCRIPTION
## What
Stop building against PHP 7.3 and 7.4

## Why
They're EOL

ping @bigcommerce/php