### PR TITLE
PHPMNT-8 Add phpstan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   ci: bigcommerce/internal@volatile
   php: bigcommerce/internal-php@volatile
 
+default_matrix: &default_matrix
+  matrix:
+    parameters:
+      php-version: [ "8.0", "8.1", "8.2" ]
+
 jobs:
   cs-fixer:
     parameters:
@@ -28,10 +33,9 @@ workflows:
     jobs:
       - php/phpunit-tests:
           configuration: "phpunit.xml.dist"
-          matrix:
-            parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+          <<: *default_matrix
       - cs-fixer:
-          matrix:
-            parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+          <<: *default_matrix
+      - php/static-analysis:
+          <<: *default_matrix
+          generate_ide_helper: false

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,0 +1,36 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Grphp\\\\StatsD\\\\ClientFactory\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/ClientFactory.php
+
+		-
+			message: "#^Method Grphp\\\\StatsD\\\\ClientFactory\\:\\:build\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/ClientFactory.php
+
+		-
+			message: "#^Property Grphp\\\\StatsD\\\\ClientFactory\\:\\:\\$config has no type specified\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/ClientFactory.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/ClientFactory.php
+
+		-
+			message: "#^Method Grphp\\\\StatsD\\\\Interceptor\\:\\:measure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/Interceptor.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method Domnikl\\\\Statsd\\\\Client\\:\\:gauge\\(\\) expects int\\|string, float given\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/Interceptor.php
+
+		-
+			message: "#^Property Grphp\\\\StatsD\\\\Interceptor\\:\\:\\$client \\(Domnikl\\\\Statsd\\\\Client\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: ../src/Grphp/StatsD/Interceptor.php

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.16",
-    "phpunit/phpunit": "^9.0"
+    "phpunit/phpunit": "^9.0",
+    "phpstan/phpstan": "^1.10"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+   level: 6
+   paths:
+     - ./src
+   bootstrapFiles:
+     - ./vendor/autoload.php
+includes:
+ - .phpstan/baseline.neon


### PR DESCRIPTION
## What/Why?
Check code with [phpstan](https://phpstan.org/)
By default, all current errors are suppressed.  
We start from [level 6](https://phpstan.org/user-guide/rule-levels) and in the future may rise a bar. 


## Testing
See circle. 

## Deploy
This tool is used only in the CI environment and should not affect production. 

## Useful links
PhpStan [documentation](https://phpstan.org/user-guide/getting-started)
