### PR TITLE
Add return types to enable compatibility with upcoming grphp 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "require": {
     "php": "^8.0",
+    "bigcommerce/grphp": "^3.0 || dev-master#59a0ea1a7d408674a6e651cee97ce267454ac9f7 as 4.0",
     "slickdeals/statsd": "^3.1"
   },
   "require-dev": {
-    "bigcommerce/grphp": "^3.0",
     "friendsofphp/php-cs-fixer": "^3.16",
     "phpunit/phpunit": "^9.0"
   },

--- a/src/Grphp/StatsD/Interceptor.php
+++ b/src/Grphp/StatsD/Interceptor.php
@@ -17,26 +17,20 @@
  */
 namespace Grphp\StatsD;
 
+use Domnikl\Statsd\Client;
 use Grphp\Client\Interceptors\Base;
+use Grphp\Client\Response;
 
 class Interceptor extends Base
 {
-    public function __construct(array $options = [])
-    {
-        parent::__construct($options);
-    }
-
-    /** @var \Domnikl\Statsd\Client $client */
-    private $client;
+    private Client $client;
 
     /**
-     * @param callable $callback
-     * @return \Grphp\Client\Response
+     * @param callable(): Response $callback
      */
-    public function call(callable $callback)
+    public function call(callable $callback): Response
     {
         $start = microtime(true);
-        /** @var \Grphp\Client\Response $response */
         $response = $callback();
         $elapsed = microtime(true) - $start;
         $elapsed = round($elapsed * 1000.00, 4);
@@ -51,7 +45,7 @@ class Interceptor extends Base
      * @param float $elapsed time elapsed in ms
      * @param bool $success if the response is a successful one or not
      */
-    private function measure($elapsed, $success = true)
+    private function measure(float $elapsed, bool $success = true)
     {
         $k = $this->key();
         $cl = $this->client();
@@ -67,26 +61,17 @@ class Interceptor extends Base
         }
     }
 
-    /**
-     * @return string
-     */
-    private function key()
+    private function key(): string
     {
         return $this->serviceKey() . '.' . $this->methodKey();
     }
 
-    /**
-     * @return mixed
-     */
-    private function methodKey()
+    private function methodKey(): mixed
     {
         return str_replace('\\', '.', strtolower($this->getMethod()));
     }
 
-    /**
-     * @return string
-     */
-    private function serviceKey()
+    private function serviceKey(): string
     {
         $s = get_class($this->getStub());
         $s = str_replace('\\', '.', $s);
@@ -97,10 +82,7 @@ class Interceptor extends Base
         return implode('.', $s);
     }
 
-    /**
-     * @return \Domnikl\Statsd\Client
-     */
-    private function client()
+    private function client(): Client
     {
         if (empty($this->client)) {
             $this->client = $this->option('client');
@@ -111,12 +93,7 @@ class Interceptor extends Base
         return $this->client;
     }
 
-    /**
-     * @param string $key
-     * @param mixed $default
-     * @return mixed
-     */
-    private function option($key, $default = null)
+    private function option(string $key, mixed $default = null): mixed
     {
         $config = $this->getOptions();
         return array_key_exists($key, $config) ? $config[$key] : $default;


### PR DESCRIPTION
## What & Why?
With `bigcommerce/grphp` version 4.0 we will require proper return type hints on the `Interceptor::call()` method. Additionally move `bigcommerce/grphp` out of the dev dependencies and into the production ones, because we depend on the base interceptor class and the response object from it.

## Testing & Proof
Using this interceptor with newer version of `grphp` results in:
```
$ ./vendor/bin/phpunit 
PHPUnit 9.6.7 by Sebastian Bergmann and contributors.

................................
Fatal error: Declaration of Grphp\StatsD\Interceptor::call(callable $callback) must be compatible with Grphp\Client\Interceptors\Base::call(callable $callback): Grphp\Client\Response in ./vendor/bigcommerce/grphp-statsd/src/Grphp/StatsD/Interceptor.php on line 36
```

Updating to the commit in this PR:
```
$ composer update
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading bigcommerce/grphp-statsd (v0.2.1 => dev-grphp-update c9e0fd9)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Upgrading bigcommerce/grphp-statsd (v0.2.1 => dev-grphp-update c9e0fd9): Extracting archive
Generating autoload files
30 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found

$ ./vendor/bin/phpunit 
PHPUnit 9.6.7 by Sebastian Bergmann and contributors.

...........................................................       59 / 59 (100%)

Time: 00:00.040, Memory: 10.00 MB
```

And still works with the older version too:
```
$ composer update
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 0 installs, 2 updates, 0 removals
  - Downgrading bigcommerce/grphp (dev-master 59a0ea1 => v3.5.2)
  - Upgrading bigcommerce/grphp-balancer (dev-grphp-version 5309bd1 => v0.0.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Downgrading bigcommerce/grphp (dev-master 59a0ea1 => v3.5.2): Extracting archive
  - Upgrading bigcommerce/grphp-balancer (dev-grphp-version 5309bd1 => v0.0.3): Extracting archive
Generating autoload files
30 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found

$ ./vendor/bin/phpunit 
PHPUnit 9.6.7 by Sebastian Bergmann and contributors.

...........................................................       59 / 59 (100%)

Time: 00:00.040, Memory: 10.00 MB

OK (59 tests, 136 assertions)
```

ping @bigcommerce/php 