### PR TITLE
Update grphp version constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 /composer.lock
 /.php_cs
 /.php_cs.cache
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.0",
-    "bigcommerce/grphp": "^3.0 || dev-master#59a0ea1a7d408674a6e651cee97ce267454ac9f7 as 4.0",
+    "bigcommerce/grphp": "^3.0 || ^4.0",
     "slickdeals/statsd": "^3.1"
   },
   "require-dev": {


### PR DESCRIPTION
## What & Why?
Now that a new version of grphp release is created, we can use a proper tag instead of locking to the commit hash on the `master` branch.

Also: add `.phpunit.result.cache` to the `.gitignore`.

ping @bigcommerce/php 