### PR TITLE
Fix cannot assign null to property Interceptor::$client

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -29,8 +29,3 @@ parameters:
 			message: "#^Parameter \\#2 \\$value of method Domnikl\\\\Statsd\\\\Client\\:\\:gauge\\(\\) expects int\\|string, float given\\.$#"
 			count: 1
 			path: ../src/Grphp/StatsD/Interceptor.php
-
-		-
-			message: "#^Property Grphp\\\\StatsD\\\\Interceptor\\:\\:\\$client \\(Domnikl\\\\Statsd\\\\Client\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: ../src/Grphp/StatsD/Interceptor.php

--- a/src/Grphp/StatsD/Interceptor.php
+++ b/src/Grphp/StatsD/Interceptor.php
@@ -85,11 +85,9 @@ class Interceptor extends Base
     private function client(): Client
     {
         if (empty($this->client)) {
-            $this->client = $this->option('client');
-            if (empty($this->client)) {
-                $this->client = ClientFactory::build($this->getOptions());
-            }
+            $this->client = $this->option('client') ?? ClientFactory::build($this->getOptions());
         }
+
         return $this->client;
     }
 


### PR DESCRIPTION
## What & Why?
We have recently added a type hint to the `Interceptor::$client` property. This will result in `TypeError(code: 0): Cannot assign null to property Grphp\StatsD\Interceptor::$client of type Domnikl\Statsd\Client` error if the client option isn't correctly set, when it actually should fallback onto instantiating one. Fix the problem by not assigning the `null` value to the `Interceptor::$client` propery if the `client` option is not set.

ping @TomA-R 