### PR TITLE
chore(platform): PHPMNT-177 Add PHP 8.4 to CircleCI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ orbs:
 default_matrix: &default_matrix
   matrix:
     parameters:
-      php-version: [ "8.0", "8.1", "8.2" ]
+      php-version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
 
 jobs:
   cs-fixer:
     parameters:
       php-version:
         type: string
-        default: "8.0"
+        default: "8.3"
     executor:
       name: php/php
       php-version: << parameters.php-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ workflows:
       - php/phpunit-tests:
           configuration: "phpunit.xml.dist"
           <<: *default_matrix
-      - cs-fixer:
-          <<: *default_matrix
+      - cs-fixer
       - php/static-analysis:
           <<: *default_matrix
           generate_ide_helper: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 default_matrix: &default_matrix
   matrix:
     parameters:
-      php-version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+      php-version: [ "8.1", "8.2", "8.3", "8.4" ]
 
 jobs:
   cs-fixer:


### PR DESCRIPTION
Jira: [PHPMNT-177](https://bigcommercecloud.atlassian.net/browse/PHPMNT-177)

WIP - needs php-cs-fixer to add support for PHP 8.4 first

## What/Why?
Add PHP 8.4 to CircleCI matrix

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-177]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ